### PR TITLE
fixed links below layer5 logo in README.md #4031

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/layer5io/layer5" alt="GitHub contributors">
+<a href="https://github.com/layer5io/layer5/graphs/contributors" alt="GitHub contributors">
 <img src="https://img.shields.io/github/contributors/layer5io/layer5.svg" /></a>
-<a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Alayer5io+org%3Ameshery+org%3Alayer5labs+org%3Aservice-mesh-performance+org%3Aservice-mesh-patterns+label%3A%22help+wanted%22" alt="Help wanted GitHub issues">
+<a href="https://github.com/layer5io/layer5/labels/help%20wanted" alt="Help wanted GitHub issues">
 <img src="https://img.shields.io/github/issues/layer5io/layer5/help%20wanted.svg?color=%23DDDD00" /></a>
 <a href="https://slack.layer5.io" alt="Slack">
 <img src="https://img.shields.io/badge/Slack-@layer5.svg?logo=slack" /></a>
 <a href="https://twitter.com/layer5" alt="Twitter Follow">
 <img src="https://img.shields.io/twitter/follow/layer5.svg?label=Follow+Layer5&style=social" /></a>
-<a href="https://github.com/layer5io/layer5" alt="License">
+<a href="https://github.com/layer5io/layer5/blob/master/LICENSE" alt="License">
 <img src="https://img.shields.io/github/license/layer5io/layer5.svg" /></a>
 </p>
 


### PR DESCRIPTION
**Description**

This PR fixes #
# The options below the Layer5 logo in README.md such as License and contributors when clicked redirect users back to the repository itself.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
